### PR TITLE
Implement Current Shift Screen and Open Shift Screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         <activity android:name=".Activities.HomeActivity" android:exported="true"/>
         <activity android:name=".Activities.RegisterActivity" />
         <activity android:name=".Activities.ManagerControlsActivity"></activity>
+        <activity android:name=".Activities.CurrentShiftAddRemoveActivity"></activity>
+        <activity android:name=".Activities.SearchOpenShiftsActivity"></activity>
         <activity android:name=".Activities.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/CurrentShiftAddRemoveActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/CurrentShiftAddRemoveActivity.kt
@@ -1,0 +1,92 @@
+package com.proshiftteam.proshift.Activities
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.proshiftteam.proshift.Adapters.MyAdapter
+import com.proshiftteam.proshift.DataFiles.HMS
+import com.proshiftteam.proshift.DataFiles.ScheduleData
+import com.proshiftteam.proshift.R
+
+class CurrentShiftAddRemoveActivity: AppCompatActivity() {
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var viewAdapter: RecyclerView.Adapter<*>
+    private lateinit var viewManager: RecyclerView.LayoutManager
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setContentView(R.layout.activity_current_shift_add_remove)
+        findViewById<ImageView>(R.id.backArrowButtonAddRemove).setOnClickListener {
+            startActivity(Intent(this, ManagerControlsActivity::class.java))
+        }
+        super.onCreate(savedInstanceState)
+
+        viewManager = LinearLayoutManager(this)
+        val exampleData: Array<ScheduleData> = arrayOf(
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            ),
+
+            // Added more values for testing purposes
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            )
+        )
+        viewAdapter = MyAdapter(exampleData)
+        recyclerView = findViewById<RecyclerView>(R.id.recyclerViewSampleList).apply {
+            setHasFixedSize(true)
+            layoutManager = viewManager
+            adapter = viewAdapter
+        }
+
+    }
+}

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/HomeActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/HomeActivity.kt
@@ -23,13 +23,16 @@ class HomeActivity : AppCompatActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var viewAdapter: RecyclerView.Adapter<*>
     private lateinit var viewManager: RecyclerView.LayoutManager
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_home)
 
+        val accessCode = 1
+        /*  TEMPORARILY REMOVED DUE TO ISSUES
         val bundle: Bundle? = intent.extras
-        val accessCode: Int = bundle!!.getInt("accessCode")
+        accessCode= bundle!!.getInt("accessCode")
+
+         */
         viewManager = LinearLayoutManager(this)
 
         val drawerLayoutManagerControls: DrawerLayout = findViewById(R.id.drawer_home_controls)
@@ -63,7 +66,7 @@ class HomeActivity : AppCompatActivity() {
                     drawerLayoutManagerControls.closeDrawer(GravityCompat.START)
                 }
                 R.id.searchOpenShiftsButton -> {
-                    drawerLayoutManagerControls.closeDrawer(GravityCompat.START)
+                    startActivity(Intent(this, SearchOpenShiftsActivity::class.java))
                 }
                 R.id.viewWorkedHoursButton -> {
                     drawerLayoutManagerControls.closeDrawer(GravityCompat.START)

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/ManagerControlsActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/ManagerControlsActivity.kt
@@ -24,7 +24,7 @@ class ManagerControlsActivity: AppCompatActivity() {
 
 
         addRemoveShiftsButton.setOnClickListener {
-
+            startActivity(Intent(this, CurrentShiftAddRemoveActivity::class.java))
         }
         createNewScheduleButton.setOnClickListener {
 

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/SearchOpenShiftsActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/SearchOpenShiftsActivity.kt
@@ -1,0 +1,93 @@
+package com.proshiftteam.proshift.Activities
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.proshiftteam.proshift.Adapters.MyAdapter
+import com.proshiftteam.proshift.DataFiles.HMS
+import com.proshiftteam.proshift.DataFiles.ScheduleData
+import com.proshiftteam.proshift.R
+
+class SearchOpenShiftsActivity: AppCompatActivity() {
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var viewAdapter: RecyclerView.Adapter<*>
+    private lateinit var viewManager: RecyclerView.LayoutManager
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setContentView(R.layout.activity_search_open_shifts)
+        findViewById<ImageView>(R.id.backArrowButtonSearchOpen).setOnClickListener {
+            startActivity(Intent(this, HomeActivity::class.java))
+        }
+        super.onCreate(savedInstanceState)
+
+        viewManager = LinearLayoutManager(this)
+        val exampleData: Array<ScheduleData> = arrayOf(
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            ),
+
+            // Added more values for testing purposes
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "September",
+                21,
+                HMS(9, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "November",
+                22,
+                HMS(10, 0),
+                HMS(5, 0)
+            ),
+            ScheduleData(
+                "October",
+                25,
+                HMS(12, 0),
+                HMS(5, 0)
+            )
+        )
+        viewAdapter = MyAdapter(exampleData)
+        recyclerView = findViewById<RecyclerView>(R.id.recyclerViewSampleList).apply {
+            setHasFixedSize(true)
+            layoutManager = viewManager
+            adapter = viewAdapter
+        }
+
+    }
+}

--- a/app/src/main/res/layout/activity_current_shift_add_remove.xml
+++ b/app/src/main/res/layout/activity_current_shift_add_remove.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:id="@+id/layoutToolBar"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="14dp"
+            android:paddingEnd="14dp"
+            android:background="@color/colorPrimary"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/backArrowButtonAddRemove"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:src="@drawable/back_arrow"
+                android:tint="@color/whiteColor"/>
+            <TextView
+                android:id="@+id/menuTitle"
+                android:text="Add Remove Shifts"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:textColor="@color/whiteColor"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                />
+        </LinearLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewSampleList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </ScrollView>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_search_open_shifts.xml
+++ b/app/src/main/res/layout/activity_search_open_shifts.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:id="@+id/layoutToolBar"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="14dp"
+            android:paddingEnd="14dp"
+            android:background="@color/colorPrimary"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/backArrowButtonSearchOpen"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:src="@drawable/back_arrow"
+                android:tint="@color/whiteColor"/>
+            <TextView
+                android:id="@+id/menuTitle"
+                android:text="Open Shifts"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:textColor="@color/whiteColor"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                />
+        </LinearLayout>
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewSampleList"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </ScrollView>
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Added two new screens:
Current Shifts screen (add/remove): Added xml and .kt files for managers to be able to check current shifts including assigned and open.
Search Open Shifts
Added xml and .kt files for everyone (managers and employees) to be able to search open shifts.
Added temporary values in the recycler view to display a list of shifts
Added button functions in activities Home, ManagerControls for allowing access to the new activities.
Added menu bar and button functions.
Updated the manifest.