### PR TITLE
Logout API implementation AND auth_token save

### DIFF
--- a/app/src/main/java/com/proshiftteam/proshift/Activities/CurrentShiftAddRemoveActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/CurrentShiftAddRemoveActivity.kt
@@ -16,11 +16,19 @@ class CurrentShiftAddRemoveActivity: AppCompatActivity() {
     private lateinit var viewAdapter: RecyclerView.Adapter<*>
     private lateinit var viewManager: RecyclerView.LayoutManager
     override fun onCreate(savedInstanceState: Bundle?) {
-        setContentView(R.layout.activity_current_shift_add_remove)
-        findViewById<ImageView>(R.id.backArrowButtonAddRemove).setOnClickListener {
-            startActivity(Intent(this, ManagerControlsActivity::class.java))
-        }
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_current_shift_add_remove)
+
+        val context = this
+        val bundle: Bundle? = intent.extras
+        val tokenCode: String? = bundle?.getString("tokenCode")
+
+        findViewById<ImageView>(R.id.backArrowButtonAddRemove).setOnClickListener {
+            val intentToManagerControlsActivity = Intent(context, ManagerControlsActivity::class.java)
+            intentToManagerControlsActivity.putExtra("tokenCode", tokenCode)
+            startActivity(intentToManagerControlsActivity)
+        }
+
 
         viewManager = LinearLayoutManager(this)
         val exampleData: Array<ScheduleData> = arrayOf(

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/MainActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/MainActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Button
 import android.widget.Toast
 import com.proshiftteam.proshift.DataFiles.LoginObject
 import com.proshiftteam.proshift.Interfaces.ApiCalls
+import com.proshiftteam.proshift.Interfaces.RetrofitBuilderObject.connectJsonApiCalls
 import com.proshiftteam.proshift.R
 import kotlinx.android.synthetic.main.activity_main.*
 import retrofit2.Call
@@ -53,12 +54,6 @@ class MainActivity : AppCompatActivity() {
 
 
                 val loginValuesObject = LoginObject(password, emailAddress)
-                val retrofitBuilder = Retrofit.Builder()
-                    .addConverterFactory(GsonConverterFactory.create())
-                    .baseUrl("http://proshiftonline.com/api/")
-                    .build()
-
-                val connectJsonApiCalls = retrofitBuilder.create(ApiCalls::class.java)
 
                 val callApiPost = connectJsonApiCalls.loginUser(loginValuesObject)
 
@@ -75,8 +70,6 @@ class MainActivity : AppCompatActivity() {
                             val accessCode = 1
                             val tokenCode = responseLoginObject?.auth_token
                             val intentToHome = Intent(context, HomeActivity::class.java)
-
-
                             intentToHome.putExtra("accessCode", accessCode)
                             intentToHome.putExtra("tokenCode", tokenCode)
                             startActivity(intentToHome)
@@ -93,5 +86,8 @@ class MainActivity : AppCompatActivity() {
 
             }
         }
+    }
+
+    override fun onBackPressed() {
     }
 }

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/ManagerControlsActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/ManagerControlsActivity.kt
@@ -17,14 +17,21 @@ class ManagerControlsActivity: AppCompatActivity() {
 
         setContentView(R.layout.activity_manager_controls)
 
+        val context = this
+        val bundle: Bundle? = intent.extras
+        val tokenCode: String? = bundle?.getString("tokenCode")
+
 
         findViewById<ImageView>(R.id.backArrowButton).setOnClickListener {
-            startActivity(Intent(this, HomeActivity::class.java))
+            val intentToHomeActivity = Intent(context, HomeActivity::class.java)
+            intentToHomeActivity.putExtra("tokenCode", tokenCode)
+            startActivity(intentToHomeActivity)
         }
 
-
         addRemoveShiftsButton.setOnClickListener {
-            startActivity(Intent(this, CurrentShiftAddRemoveActivity::class.java))
+            val intentToCurrentShiftAddRemoveActivity = Intent(context, CurrentShiftAddRemoveActivity::class.java)
+            intentToCurrentShiftAddRemoveActivity.putExtra("tokenCode", tokenCode)
+            startActivity(intentToCurrentShiftAddRemoveActivity)
         }
         createNewScheduleButton.setOnClickListener {
 

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/RegisterActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/RegisterActivity.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import com.proshiftteam.proshift.DataFiles.Registration
 import com.proshiftteam.proshift.DataFiles.RegistrationResponse
 import com.proshiftteam.proshift.Interfaces.ApiCalls
+import com.proshiftteam.proshift.Interfaces.RetrofitBuilderObject.connectJsonApiCalls
 import com.proshiftteam.proshift.R
 import kotlinx.android.synthetic.main.activity_register.*
 import okhttp3.OkHttpClient
@@ -38,15 +39,6 @@ class RegisterActivity : AppCompatActivity() {
             val rePasswordEntered = editTextConfirmPassword.text.toString()
 
             val newRegistration = Registration(userNameEntered,firstNameEntered,lastNameEntered,phoneNumberEntered,companyCodeEntered,emailAddressEntered,passwordEntered,rePasswordEntered)
-
-
-
-            val retrofitBuilder = Retrofit.Builder()
-                .addConverterFactory(GsonConverterFactory.create())
-                .baseUrl("http://proshiftonline.com/api/")
-                .build()
-
-            val connectJsonApiCalls = retrofitBuilder.create(ApiCalls::class.java)
 
             val callApiPost = connectJsonApiCalls.registerUser(newRegistration)
 

--- a/app/src/main/java/com/proshiftteam/proshift/Activities/SearchOpenShiftsActivity.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Activities/SearchOpenShiftsActivity.kt
@@ -17,11 +17,18 @@ class SearchOpenShiftsActivity: AppCompatActivity() {
     private lateinit var viewAdapter: RecyclerView.Adapter<*>
     private lateinit var viewManager: RecyclerView.LayoutManager
     override fun onCreate(savedInstanceState: Bundle?) {
-        setContentView(R.layout.activity_search_open_shifts)
-        findViewById<ImageView>(R.id.backArrowButtonSearchOpen).setOnClickListener {
-            startActivity(Intent(this, HomeActivity::class.java))
-        }
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_search_open_shifts)
+        val context = this
+        val bundle: Bundle? = intent.extras
+        val tokenCode: String? = bundle?.getString("tokenCode")
+
+        findViewById<ImageView>(R.id.backArrowButtonSearchOpen).setOnClickListener {
+            val intentToHomeActivity = Intent(context, HomeActivity::class.java)
+            intentToHomeActivity.putExtra("tokenCode", tokenCode)
+            startActivity(intentToHomeActivity)
+        }
+
 
         viewManager = LinearLayoutManager(this)
         val exampleData: Array<ScheduleData> = arrayOf(

--- a/app/src/main/java/com/proshiftteam/proshift/DataFiles/LogoutObject.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/DataFiles/LogoutObject.kt
@@ -1,0 +1,5 @@
+package com.proshiftteam.proshift.DataFiles
+
+data class LogoutObject (
+    var auth_token: String? =""
+)

--- a/app/src/main/java/com/proshiftteam/proshift/Interfaces/ApiCalls.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Interfaces/ApiCalls.kt
@@ -2,11 +2,10 @@ package com.proshiftteam.proshift.Interfaces
 
 
 import com.proshiftteam.proshift.DataFiles.LoginObject
+import com.proshiftteam.proshift.DataFiles.LogoutObject
 import com.proshiftteam.proshift.DataFiles.Registration
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface ApiCalls {
 
@@ -15,4 +14,11 @@ interface ApiCalls {
 
     @POST("token/login/")
     fun loginUser(@Body loginObject: LoginObject): Call <LoginObject>
+
+    @Headers(
+        "Accepts: application/json",
+        "Content-Type: application/json"
+    )
+    @POST("token/logout")
+    fun logoutUser(@Header("Authorization") token: String?, @Body logoutObject: LogoutObject): Call<LogoutObject>
 }

--- a/app/src/main/java/com/proshiftteam/proshift/Interfaces/RetrofitBuilderObject.kt
+++ b/app/src/main/java/com/proshiftteam/proshift/Interfaces/RetrofitBuilderObject.kt
@@ -1,0 +1,13 @@
+package com.proshiftteam.proshift.Interfaces
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitBuilderObject {
+    val retrofitBuilder = Retrofit.Builder()
+        .addConverterFactory(GsonConverterFactory.create())
+        .baseUrl("http://proshiftonline.com/api/")
+        .build()
+
+    val connectJsonApiCalls = retrofitBuilder.create(ApiCalls::class.java)
+}


### PR DESCRIPTION
Added API calls for logging out the user.
Displays a succesfully logged out user, along with the response code(response codes will be removed later throughout the app)
Added code so that once the user is logged out, they can no longer go back to the previous screen unless they log in.
The auth_token is now saved in all the activities for futher use.
Created a new file for retrofit builder so the code is easier to maintain.