### PR TITLE
Clean up and show more details on admin panel

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -10,6 +10,8 @@ class EmployeeStatusInline(admin.StackedInline):
     verbose_name_plural = 'Employement'
     fk_name = 'user'
     extra = 0
+    fields = ('get_id', 'company', 'position')
+    readonly_fields = ('get_id', )
 
 class UserAdmin(admin.ModelAdmin):
     list_display = ('email', 'username', 'first_name', 'last_name', 'company_code', 'phone', 'id')
@@ -45,7 +47,6 @@ admin.site.register(User, UserAdmin)
 admin.site.register(Shift, ShiftAdmin)
 admin.site.register(Company, CompanyAdmin)
 admin.site.register(Position, PositionAdmin)
-admin.site.register(EmployeeRole, EmployeeRoleAdmin)
 admin.site.register(RequestedTimeOff, RequestedTimeOffAdmin)
 admin.site.register(Availability, AvailabilityAdmin)
 admin.site.register(ShiftRequest, ShiftRequestAdmin)

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -55,6 +55,9 @@ class EmployeeRole(models.Model):
 
     def __str__(self):
         return str(self.user) + " | " + str(self.position)
+    
+    def get_id(self):
+        return self.id
 
 @receiver(post_save, sender=User)
 def create_or_update_user_profile(sender, instance, created, **kwargs):


### PR DESCRIPTION
Closes #104 
- Use correct plural names
- Show ids for all models
- Show columns for all models
- Remove EmployeeRole from panel (only showing it in the User models as a stackedinline)